### PR TITLE
Potential fix for code scanning alert no. 45: Useless regular-expression character escape

### DIFF
--- a/Open-ILS/src/eg2/src/app/staff/reporter/full/my-templates.component.html
+++ b/Open-ILS/src/eg2/src/app/staff/reporter/full/my-templates.component.html
@@ -51,10 +51,10 @@
 ></eg-prompt-dialog>
 
 <ng-template #docURLTmpl let-row="row">
-  <div *ngIf="row.documentation?.match('^\s*https?:')">
+  <div *ngIf="row.documentation?.match('^\\s*https?:')">
     <a href="{{row.documentation}}" target="_blank" i18n>Template Documentation</a>
   </div>
-  <span *ngIf="!row.documentation?.match('^\s*https?:')">
+  <span *ngIf="!row.documentation?.match('^\\s*https?:')">
     {{row.documentation}}
   </span>
 </ng-template>


### PR DESCRIPTION
Potential fix for [https://github.com/IanSkelskey/Evergreen/security/code-scanning/45](https://github.com/IanSkelskey/Evergreen/security/code-scanning/45)

To fix the problem, we need to ensure that the backslash in the escape sequence `\s` is correctly interpreted in the string literal. This can be achieved by doubling the backslash to `\\s`. This change will ensure that the regular expression correctly matches optional leading whitespace.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
