### PR TITLE
Potential fix for code scanning alert no. 44: Useless regular-expression character escape

### DIFF
--- a/Open-ILS/src/eg2/src/app/staff/reporter/full/my-reports.component.html
+++ b/Open-ILS/src/eg2/src/app/staff/reporter/full/my-reports.component.html
@@ -62,7 +62,7 @@
   <div *ngIf="row.documentation?.match('^\s*https?:')">
     <a href="{{row.documentation}}" target="_blank" i18n>Template Documentation</a>
   </div>
-  <span *ngIf="!row.documentation?.match('^\s*https?:')">
+  <span *ngIf="!row.documentation?.match('^\\s*https?:')">
     {{row.documentation}}
   </span>
 </ng-template>


### PR DESCRIPTION
Potential fix for [https://github.com/IanSkelskey/Evergreen/security/code-scanning/44](https://github.com/IanSkelskey/Evergreen/security/code-scanning/44)

To fix the problem, we need to ensure that the backslash in the escape sequence `\s` is correctly interpreted in the string literal. This can be done by doubling the backslash to `\\s`, which will be correctly interpreted as a single backslash in the regular expression.

- Change the escape sequence `\s` to `\\s` in the string literal.
- This change should be made in the file `Open-ILS/src/eg2/src/app/staff/reporter/full/my-reports.component.html` on line 65.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
