### PR TITLE
Potential fix for code scanning alert no. 43: Useless regular-expression character escape

### DIFF
--- a/Open-ILS/src/eg2/src/app/staff/reporter/full/definition.component.html
+++ b/Open-ILS/src/eg2/src/app/staff/reporter/full/definition.component.html
@@ -60,8 +60,8 @@
 	  <label class="form-label" i18n>Template Documentation</label>
 	</div>
 	<div class="col-lg-8">
-  	<a *ngIf="templ.doc_url.match('\s*https?:')" id="documentation-link" href="{{templ.doc_url}}">{{templ.doc_url}}</a>
-  	<span *ngIf="!templ.doc_url.match('\s*https?:')" id="documentation-text">{{templ.doc_url}}</span>
+  	<a *ngIf="templ.doc_url.match('\\s*https?:')" id="documentation-link" href="{{templ.doc_url}}">{{templ.doc_url}}</a>
+  	<span *ngIf="!templ.doc_url.match('\\s*https?:')" id="documentation-text">{{templ.doc_url}}</span>
 	</div>
 </div>
 


### PR DESCRIPTION
Potential fix for [https://github.com/IanSkelskey/Evergreen/security/code-scanning/43](https://github.com/IanSkelskey/Evergreen/security/code-scanning/43)

To fix the problem, we need to ensure that the escape sequence `\s` is correctly interpreted as a whitespace character in the regular expression. This can be achieved by using double backslashes `\\s` within the string literal to correctly escape the backslash character. This way, the regular expression will correctly match any whitespace character.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
