### PR TITLE
Potential fix for code scanning alert no. 41: Double escaping or unescaping

### DIFF
--- a/Open-ILS/xul/staff_client/chrome/content/util/text.js
+++ b/Open-ILS/xul/staff_client/chrome/content/util/text.js
@@ -36,12 +36,12 @@ util.text.preserve_string_in_html = function( text ) {
 }
 
 util.text.reverse_preserve_string_in_html = function( text ) {
-    text = text.replace(/&amp;/g, '&');
     text = text.replace(/&quot;/g, '"');
     text = text.replace(/&#39;/g, "'");
     text = text.replace(/&nbsp;/g, ' ');
     text = text.replace(/&lt;/g, '<');
     text = text.replace(/&gt;/g, '>');
+    text = text.replace(/&amp;/g, '&');
     return text;
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/IanSkelskey/Evergreen/security/code-scanning/41](https://github.com/IanSkelskey/Evergreen/security/code-scanning/41)

To fix the problem, we need to ensure that the `&amp;` entity is unescaped last in the `reverse_preserve_string_in_html` function. This will prevent double unescaping of other entities that include the `&` character. The best way to fix this is to reorder the replacement operations in the `reverse_preserve_string_in_html` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
