### PR TITLE
Potential fix for code scanning alert no. 40: Double escaping or unescaping

### DIFF
--- a/Open-ILS/web/js/ui/default/staff/services/hatch.js
+++ b/Open-ILS/web/js/ui/default/staff/services/hatch.js
@@ -1017,12 +1017,12 @@ angular.module('egCoreMod')
 
     // COPIED FROM XUL util/text.js
     service.reverse_preserve_string_in_html = function( text ) {
-        text = text.replace(/&amp;/g, '&');
         text = text.replace(/&quot;/g, '"');
         text = text.replace(/&#39;/g, "'");
         text = text.replace(/&nbsp;/g, ' ');
         text = text.replace(/&lt;/g, '<');
         text = text.replace(/&gt;/g, '>');
+        text = text.replace(/&amp;/g, '&');
         return text;
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/IanSkelskey/Evergreen/security/code-scanning/40](https://github.com/IanSkelskey/Evergreen/security/code-scanning/40)

To fix the problem, we need to ensure that the `&amp;` entity is unescaped last in the `reverse_preserve_string_in_html` function. This will prevent double unescaping issues where sequences like `&amp;quot;` are incorrectly converted.

- We will reorder the replacement calls in the `reverse_preserve_string_in_html` function so that `&amp;` is unescaped last.
- This change will be made in the file `Open-ILS/web/js/ui/default/staff/services/hatch.js` on lines 1020-1025.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
