### PR TITLE
Potential fix for code scanning alert no. 10: Insecure randomness

### DIFF
--- a/Open-ILS/web/js/ui/default/staff/circ/patron/regctl.js
+++ b/Open-ILS/web/js/ui/default/staff/circ/patron/regctl.js
@@ -1707,7 +1707,9 @@ function($scope , $routeParams , $q , $uibModal , $window , egCore ,
 
     // generates a random 4-digit password
     $scope.generate_password = function() {
-        $scope.patron.passwd = Math.floor(Math.random()*9000) + 1000;
+        var array = new Uint32Array(1);
+        window.crypto.getRandomValues(array);
+        $scope.patron.passwd = Math.floor(array[0] / (0xFFFFFFFF + 1) * 9000) + 1000;
     }
 
     $scope.send_password_reset_link = function() {


### PR DESCRIPTION
Potential fix for [https://github.com/IanSkelskey/Evergreen/security/code-scanning/10](https://github.com/IanSkelskey/Evergreen/security/code-scanning/10)

To fix the problem, we need to replace the use of `Math.random()` with a cryptographically secure random number generator. In the browser environment, we can use `window.crypto.getRandomValues` to generate secure random numbers. This will ensure that the generated passwords are not easily predictable.

Specifically, we will:
1. Replace the `Math.random()` call with `window.crypto.getRandomValues`.
2. Convert the generated random value to a number within the desired range (1000 to 9999).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
