### PR TITLE
Potential fix for code scanning alert no. 7: Prototype-polluting function

### DIFF
--- a/Open-ILS/web/js/ui/default/staff/services/idl.js
+++ b/Open-ILS/web/js/ui/default/staff/services/idl.js
@@ -286,6 +286,7 @@ angular.module('egCoreMod')
             var last_key;
             for (var i = 0; i < parts.length; i++) {
                 var part = parts[i];
+                if (part === "__proto__" || part === "constructor") continue;
                 if (i == parts.length - 1) {
                     sub_hash[part] = val;
                     break;


### PR DESCRIPTION
Potential fix for [https://github.com/IanSkelskey/Evergreen/security/code-scanning/7](https://github.com/IanSkelskey/Evergreen/security/code-scanning/7)

To fix the problem, we need to ensure that the function `service.flatToNestedHash` does not allow the assignment of dangerous properties like `__proto__` or `constructor`. This can be achieved by adding a check to skip these properties during the assignment process.

- Modify the `service.flatToNestedHash` function to include a check that skips the assignment if the property name is `__proto__` or `constructor`.
- This change should be made in the file `Open-ILS/web/js/ui/default/staff/services/idl.js` within the `service.flatToNestedHash` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
