### PR TITLE
Potential fix for code scanning alert no. 39: Double escaping or unescaping

### DIFF
--- a/Open-ILS/src/eg2/src/app/share/util/htmltotxt.service.ts
+++ b/Open-ILS/src/eg2/src/app/share/util/htmltotxt.service.ts
@@ -10,11 +10,11 @@ const ENTITY_REGEX = /&[^\s]+;/;
 export class HtmlToTxtService {
 
     unEscapeHtml(text: string): string {
-        text = text.replace(/&amp;/g, '&');
         text = text.replace(/&quot;/g, '"');
         text = text.replace(/&nbsp;/g, ' ');
         text = text.replace(/&lt;/g, '<');
         text = text.replace(/&gt;/g, '>');
+        text = text.replace(/&amp;/g, '&');
         return text;
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/IanSkelskey/Evergreen/security/code-scanning/39](https://github.com/IanSkelskey/Evergreen/security/code-scanning/39)

To fix the problem, we need to ensure that the `&amp;` entity is unescaped last. This will prevent any issues with double unescaping other entities that include `&amp;` in their representation. We will reorder the replacements in the `unEscapeHtml` function to unescape `&amp;` after all other entities.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
