### PR TITLE
Potential fix for code scanning alert no. 38: Incomplete string escaping or encoding

### DIFF
--- a/Open-ILS/web/js/ui/default/staff/marcrecord.js
+++ b/Open-ILS/web/js/ui/default/staff/marcrecord.js
@@ -277,8 +277,8 @@ var MARC21 = {
             function cf_line_data (l) { return l.substring(4) || '' };
             function df_line_data (l) { return l.substring(6) || '' };
             function line_tag (l) { return l.substring(0,3) };
-            function df_ind1 (l) { return l.substring(4,5).replace('\\',' ') };
-            function df_ind2 (l) { return l.substring(5,6).replace('\\',' ') };
+            function df_ind1 (l) { return l.substring(4,5).replace(/\\/g,' ') };
+            function df_ind2 (l) { return l.substring(5,6).replace(/\\/g,' ') };
             function isControlField (l) {
                 var x = line_tag(l);
                 return (x == 'LDR' || x < '010') ? true : false;


### PR DESCRIPTION
Potential fix for [https://github.com/IanSkelskey/Evergreen/security/code-scanning/38](https://github.com/IanSkelskey/Evergreen/security/code-scanning/38)

To fix the problem, we need to ensure that all occurrences of the backslash character are replaced with a space. This can be achieved by using a regular expression with the global flag (`g`). This change will ensure that every backslash in the substring is replaced, not just the first one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
