### PR TITLE
Potential fix for code scanning alert no. 17: Incomplete multi-character sanitization

### DIFF
--- a/Open-ILS/src/eg2/src/app/share/util/htmltotxt.service.ts
+++ b/Open-ILS/src/eg2/src/app/share/util/htmltotxt.service.ts
@@ -42,7 +42,11 @@ export class HtmlToTxtService {
         //       but as of 2019-12-27 Firefox does not support
         //       the ES2018 regexp dotAll flag and Angular/tsc doesn't
         //       seem set up to transpile it
-        html = html.replace(/<!--([^]*?)-->/g, '');
+        let previousHtml;
+        do {
+            previousHtml = html;
+            html = html.replace(/<!--([^]*?)-->/g, '');
+        } while (html !== previousHtml);
 
         const lines = html.split(/\n/);
         const newLines = [];


### PR DESCRIPTION
Potential fix for [https://github.com/IanSkelskey/Evergreen/security/code-scanning/17](https://github.com/IanSkelskey/Evergreen/security/code-scanning/17)

To fix the problem, we need to ensure that the regular expression replacement for removing HTML comments is applied repeatedly until no more replacements can be performed. This will ensure that all instances of HTML comments are removed, even if they are nested or consecutive.

- Modify the `htmlToTxt` method to apply the regular expression replacement for HTML comments in a loop until no more replacements are made.
- This change will be made in the file `Open-ILS/src/eg2/src/app/share/util/htmltotxt.service.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
