### PR TITLE
Potential fix for code scanning alert no. 8: Prototype-polluting function

### DIFF
--- a/Open-ILS/web/reports/oils_rpt_utils.js
+++ b/Open-ILS/web/reports/oils_rpt_utils.js
@@ -185,6 +185,7 @@ function buildFloatingDiv(div, width) {
 
 function mergeObjects( src, obj ) {
 	for( var i in obj ) {
+		if (!obj.hasOwnProperty(i) || i === "__proto__" || i === "constructor") continue;
 		if( typeof obj[i] == 'string' ) {
 			src[i] = obj[i];
 		} else {


### PR DESCRIPTION
Potential fix for [https://github.com/IanSkelskey/Evergreen/security/code-scanning/8](https://github.com/IanSkelskey/Evergreen/security/code-scanning/8)

To fix the problem, we need to ensure that the `mergeObjects` function does not allow prototype pollution. This can be achieved by:
1. Blocking the property names `__proto__` and `constructor` from being merged or assigned to.
2. Ensuring that only own properties of the source object are merged recursively.

We will modify the `mergeObjects` function to include these safeguards.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
