### PR TITLE
Potential fix for code scanning alert no. 36: Incomplete string escaping or encoding

### DIFF
--- a/Open-ILS/web/js/ui/default/booking/populator.js
+++ b/Open-ILS/web/js/ui/default/booking/populator.js
@@ -329,7 +329,7 @@ function display_transit_slip(e) {
             [ma.street1(),ma.street2(),ma.city(),ma.state(),ma.post_code()].map(
                 function(o) { return o ? o : ""; }
             )
-        ).replace("\n\n", "\n").replace("\n", "<br />") : "[Unknown address]";
+        ).replace(/\n\n/g, "\n").replace(/\n/g, "<br />") : "[Unknown address]";
     /* XXX i18n and/or template */
     try {
         var win = window.open(


### PR DESCRIPTION
Potential fix for [https://github.com/IanSkelskey/Evergreen/security/code-scanning/36](https://github.com/IanSkelskey/Evergreen/security/code-scanning/36)

To fix the problem, we need to ensure that all occurrences of the newline character (`\n`) are replaced, not just the first one. This can be achieved by using a regular expression with the global flag (`g`). Specifically, we will replace the `replace("\n\n", "\n")` and `replace("\n", "<br />")` calls with their respective regular expression equivalents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
