### PR TITLE
Potential fix for code scanning alert no. 35: Incomplete string escaping or encoding

### DIFF
--- a/Open-ILS/web/js/dojo/openils/widget/XULTermLoader.js
+++ b/Open-ILS/web/js/dojo/openils/widget/XULTermLoader.js
@@ -130,7 +130,7 @@ if (!dojo._hasResource["openils.widget.XULTermLoader"]) {
                 if (!data) return [];
                 else return data.split("\n").
                     filter(function(o) { return o.length > 0; }).
-                    map(function(o) {return o.replace("\r","").split(",")[0];}).
+                    map(function(o) {return o.replace(/\r/g,"").split(",")[0];}).
                     filter(function(o) { return o.length > 0; });
             }
         }


### PR DESCRIPTION
Potential fix for [https://github.com/IanSkelskey/Evergreen/security/code-scanning/35](https://github.com/IanSkelskey/Evergreen/security/code-scanning/35)

To fix the problem, we need to ensure that all occurrences of `\r` are replaced in the string. This can be achieved by using a regular expression with the global flag (`g`). This change will ensure that every instance of `\r` in the string is replaced, not just the first one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
