### PR TITLE
Potential fix for code scanning alert no. 34: Incomplete string escaping or encoding

### DIFF
--- a/Open-ILS/web/js/dojo/openils/PermaCrud/Store.js
+++ b/Open-ILS/web/js/dojo/openils/PermaCrud/Store.js
@@ -276,7 +276,7 @@ if (!dojo._hasResource["openils.PermaCrud.Store"]) {
                         hashparts[i] = key + ":%";
                     }
                 } else {
-                    term = term.replace("%", "%%");
+                    term = term.replace(/%/g, "%%");
                     term = term.replace(/\*$/, "%");
 
                     if (dojo.indexOf(term, "%") != -1) op = "like";


### PR DESCRIPTION
Potential fix for [https://github.com/IanSkelskey/Evergreen/security/code-scanning/34](https://github.com/IanSkelskey/Evergreen/security/code-scanning/34)

To fix the problem, we need to ensure that all occurrences of the `%` character in the `term` string are replaced with `%%`. This can be achieved by using a regular expression with the global flag (`g`). This change will ensure that every `%` character in the `term` string is replaced, not just the first one.

The specific change required is to modify the `term.replace` call on line 279 to use a regular expression with the global flag. No additional imports or definitions are needed for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
