### PR TITLE
Potential fix for code scanning alert no. 33: Incomplete string escaping or encoding

### DIFF
--- a/Open-ILS/web/js/dojo/MARC/Record.js
+++ b/Open-ILS/web/js/dojo/MARC/Record.js
@@ -240,7 +240,7 @@ if(!dojo._hasResource["MARC.Record"]) {
             function df_line_data (l) { return l.substring(6) || '' };
             function line_tag (l) { return l.substring(0,3) };
             function df_ind1 (l) { return l.substring(4,5).replace('\\',' ') };
-            function df_ind2 (l) { return l.substring(5,6).replace('\\',' ') };
+            function df_ind2 (l) { return l.substring(5,6).replace(/\\/g,' ') };
             function isControlField (l) {
                 var x = line_tag(l);
                 return (x == 'LDR' || x < '010') ? true : false;


### PR DESCRIPTION
Potential fix for [https://github.com/IanSkelskey/Evergreen/security/code-scanning/33](https://github.com/IanSkelskey/Evergreen/security/code-scanning/33)

To fix the problem, we need to ensure that all occurrences of the backslash character are replaced with a space. This can be achieved by using a regular expression with the global flag (`g`). This way, every backslash in the substring will be replaced, not just the first one.

We will update the `replace` method on line 243 to use a regular expression with the global flag. This change will ensure that all backslashes are replaced with spaces.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
