### PR TITLE
Potential fix for code scanning alert no. 29: Incomplete string escaping or encoding

### DIFF
--- a/Open-ILS/src/eg2/src/app/staff/acq/lineitem/from-bib-ids.component.ts
+++ b/Open-ILS/src/eg2/src/app/staff/acq/lineitem/from-bib-ids.component.ts
@@ -119,7 +119,7 @@ export class LineitemFromBibIdsComponent implements OnInit {
                     this.bibIdMap[f.name] = (e.target.result as string). // text content
                         split('\n'). // split to lines
             	        filter(o => Boolean(o.length > 0)). // line isn't empty
-        	            map(l => l.replace('\r','').split(',')[0]). // take first field
+        	            map(l => l.replace(/\r/g,'').split(',')[0]). // take first field
             	        filter(o => Boolean(o.length > 0)). // first field has content
                         map(o => o.match(/^".+"$/) ? o.slice(1,-1) : o). // remove quotes
                         filter(o => Boolean(o.match(/^\d+$/))). // and it's a number


### PR DESCRIPTION
Potential fix for [https://github.com/IanSkelskey/Evergreen/security/code-scanning/29](https://github.com/IanSkelskey/Evergreen/security/code-scanning/29)

To fix the problem, we need to ensure that all occurrences of the `\r` character are replaced in the string. This can be achieved by using a regular expression with the global flag (`g`). This change will ensure that every `\r` character in the string is replaced, not just the first one.

We will modify the `replace` method on line 122 to use a regular expression with the global flag. No additional imports or dependencies are required for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
