### PR TITLE
Potential fix for code scanning alert no. 12: DOM text reinterpreted as HTML

### DIFF
--- a/Open-ILS/src/extras/opensearchportal.html
+++ b/Open-ILS/src/extras/opensearchportal.html
@@ -160,7 +160,12 @@ function opensearch ( term, reset, single_source ) {
 			if (cur_src.childNodes[i].nodeValue == turi)
 				return;
 		}
-		cur_src.innerHTML += '<a name="' + single_source + '" href="' + turi + '">' + turi + '</a><br>';
+		var a = document.createElement('a');
+		a.name = single_source;
+		a.href = turi;
+		a.textContent = turi;
+		cur_src.appendChild(a);
+		cur_src.appendChild(document.createElement('br'));
 		perform_search(single_source);
 		return;
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/IanSkelskey/Evergreen/security/code-scanning/12](https://github.com/IanSkelskey/Evergreen/security/code-scanning/12)

To fix the problem, we need to ensure that the user-controlled input (`turi`) is properly escaped before being inserted into the HTML. This can be achieved by creating a text node and setting its properties instead of using `innerHTML`. This approach ensures that any special characters in the URL are properly escaped, preventing XSS attacks.

- Replace the use of `innerHTML` with a method that safely creates and appends the new elements.
- Specifically, create an anchor (`<a>`) element, set its attributes using safe methods, and then append it to the parent element.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
